### PR TITLE
Add min/maximumInclusive properties to RangeFilter

### DIFF
--- a/filter.cpp
+++ b/filter.cpp
@@ -218,6 +218,21 @@ void RangeFilter::setMinimumValue(QVariant minimumValue)
     emit filterChanged();
 }
 
+bool RangeFilter::minimumInclusive() const
+{
+    return m_minimumInclusive;
+}
+
+void RangeFilter::setMinimumInclusive(bool minimumInclusive)
+{
+    if (m_minimumInclusive == minimumInclusive)
+        return;
+
+    m_minimumInclusive = minimumInclusive;
+    emit minimumInclusiveChanged();
+    emit filterChanged();
+}
+
 QVariant RangeFilter::maximumValue() const
 {
     return m_maximumValue;
@@ -233,11 +248,28 @@ void RangeFilter::setMaximumValue(QVariant maximumValue)
     emit filterChanged();
 }
 
+bool RangeFilter::maximumInclusive() const
+{
+    return m_maximumInclusive;
+}
+
+void RangeFilter::setMaximumInclusive(bool maximumInclusive)
+{
+    if (m_maximumInclusive == maximumInclusive)
+        return;
+
+    m_maximumInclusive = maximumInclusive;
+    emit maximumInclusiveChanged();
+    emit filterChanged();
+}
+
 bool RangeFilter::filterRow(const QModelIndex& sourceIndex) const
 {
     QVariant value = sourceData(sourceIndex);
-    bool lessThanMin = m_minimumValue.isValid() && value < m_minimumValue;
-    bool moreThanMax = m_maximumValue.isValid() && value > m_maximumValue;
+    bool lessThanMin = m_minimumValue.isValid() &&
+            m_minimumInclusive ? value < m_minimumValue : value <= m_minimumValue;
+    bool moreThanMax = m_maximumValue.isValid() &&
+            m_maximumInclusive ? value > m_maximumValue : value >= m_maximumValue;
     return !(lessThanMin || moreThanMax);
 }
 

--- a/filter.h
+++ b/filter.h
@@ -156,27 +156,37 @@ class RangeFilter : public RoleFilter
 {
     Q_OBJECT
     Q_PROPERTY(QVariant minimumValue READ minimumValue WRITE setMinimumValue NOTIFY minimumValueChanged)
+    Q_PROPERTY(bool minimumInclusive READ minimumInclusive WRITE setMinimumInclusive NOTIFY minimumInclusiveChanged)
     Q_PROPERTY(QVariant maximumValue READ maximumValue WRITE setMaximumValue NOTIFY maximumValueChanged)
+    Q_PROPERTY(bool maximumInclusive READ maximumInclusive WRITE setMaximumInclusive NOTIFY maximumInclusiveChanged)
 
 public:
     using RoleFilter::RoleFilter;
 
     QVariant minimumValue() const;
     void setMinimumValue(QVariant minimumValue);
+    bool minimumInclusive() const;
+    void setMinimumInclusive(bool minimumInclusive);
 
     QVariant maximumValue() const;
     void setMaximumValue(QVariant maximumValue);
+    bool maximumInclusive() const;
+    void setMaximumInclusive(bool maximumInclusive);
 
 protected:
     bool filterRow(const QModelIndex& sourceIndex) const override;
 
 signals:
     void minimumValueChanged();
+    void minimumInclusiveChanged();
     void maximumValueChanged();
+    void maximumInclusiveChanged();
 
 private:
     QVariant m_minimumValue;
+    bool m_minimumInclusive = true;
     QVariant m_maximumValue;
+    bool m_maximumInclusive = true;
 };
 
 class ExpressionFilter : public Filter


### PR DESCRIPTION
* Allow one to configure RangeFilters to be able to exclude the
  minimum and/or maximum values in the range.
* Defaults to including both minimum and maximum values, leaving prior
  behavior unchanged.