### PR TITLE
Improve warning to handle C++14 case

### DIFF
--- a/SortFilterProxyModel.pri
+++ b/SortFilterProxyModel.pri
@@ -1,4 +1,4 @@
-!c++11: warning("SortFilterProxyModel needs c++11, add CONFIG += c++11 to your .pro")
+!contains( CONFIG, c\+\+1[14] ): warning("SortFilterProxyModel needs at least c++11, add CONFIG += c++11 to your .pro")
 
 INCLUDEPATH += $$PWD
 


### PR DESCRIPTION
If you use SortFilterProxyModel in a C++14 project you constantly get a warning about requiring C++11 support, which is quite annoying :).