### PR TITLE
tst_stringsorter.qml -> doNotIgnorePunctuation fallback

### DIFF
--- a/tests/tst_stringsorter.qml
+++ b/tests/tst_stringsorter.qml
@@ -42,7 +42,11 @@ Item {
         },
         StringSorter {
             property string tag: "doNotIgnorePunctuation"
-            property var expectedValues: ["aa", "a-a", "b.c", "b-b", "bc", "b-c"]
+            // depends on ICU usage (TODO: howto check on compiletime?)
+            // with ICU support: (Qt with ICU configured)
+            //property var expectedValues: ["a-a", "aa", "b.c", "b-b", "bc", "b-c"]
+            // without ICU support (default: Linux, Apple platforms):
+            property var expectedValues: ["a-a", "aa", "b-b", "b-c", "b.c", "bc"]
             roleName: "punctuationRole"
             ignorePunctation: false
         }


### PR DESCRIPTION
Hey,

as explained in the commit, on Linux and Apple based Systems Qt5 is not supporting ICU.

The out of the box test will fail for doNotIgnorePunctuation. I have no clue, on howto use a preprocessor check at buildtime to get arround other then comment out and fall back to do IgnorePuctuation.

Cheers
Ralf