### PR TITLE
Support Qt in namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ add_library(SortFilterProxyModel OBJECT
     proxyroles/filterrole.cpp
     )
 
+target_compile_definitions(SortFilterProxyModel PUBLIC
+    $<TARGET_PROPERTY:Qt5::Core,INTERFACE_COMPILE_DEFINITIONS>
+    )
+
 target_include_directories(SortFilterProxyModel PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
     $<TARGET_PROPERTY:Qt5::Core,INTERFACE_INCLUDE_DIRECTORIES>

--- a/filters/expressionfilter.h
+++ b/filters/expressionfilter.h
@@ -4,7 +4,7 @@
 #include "filter.h"
 #include <QQmlScriptString>
 
-class QQmlExpression;
+class QT_PREPEND_NAMESPACE(QQmlExpression);
 
 namespace qqsfpm {
 

--- a/filters/filtercontainer.h
+++ b/filters/filtercontainer.h
@@ -36,7 +36,9 @@ private:
 
 }
 
+QT_BEGIN_NAMESPACE
 #define FilterContainer_iid "fr.grecko.SortFilterProxyModel.FilterContainer"
 Q_DECLARE_INTERFACE(qqsfpm::FilterContainer, FilterContainer_iid)
+QT_END_NAMESPACE
 
 #endif // FILTERCONTAINER_H

--- a/proxyroles/expressionrole.h
+++ b/proxyroles/expressionrole.h
@@ -4,7 +4,7 @@
 #include "singlerole.h"
 #include <QQmlScriptString>
 
-class QQmlExpression;
+class QT_PREPEND_NAMESPACE(QQmlExpression);
 
 namespace qqsfpm {
 

--- a/proxyroles/proxyrolecontainer.h
+++ b/proxyroles/proxyrolecontainer.h
@@ -36,7 +36,9 @@ private:
 
 }
 
+QT_BEGIN_NAMESPACE
 #define ProxyRoleContainer_iid "fr.grecko.SortFilterProxyModel.ProxyRoleContainer"
 Q_DECLARE_INTERFACE(qqsfpm::ProxyRoleContainer, ProxyRoleContainer_iid)
+QT_END_NAMESPACE
 
 #endif // PROXYROLECONTAINER_H

--- a/sorters/expressionsorter.h
+++ b/sorters/expressionsorter.h
@@ -4,7 +4,7 @@
 #include "sorter.h"
 #include <QQmlScriptString>
 
-class QQmlExpression;
+class QT_PREPEND_NAMESPACE(QQmlExpression);
 
 namespace qqsfpm {
 

--- a/sorters/sortercontainer.h
+++ b/sorters/sortercontainer.h
@@ -36,7 +36,9 @@ private:
 
 }
 
+QT_BEGIN_NAMESPACE
 #define SorterContainer_iid "fr.grecko.SortFilterProxyModel.SorterContainer"
 Q_DECLARE_INTERFACE(qqsfpm::SorterContainer, SorterContainer_iid)
+QT_END_NAMESPACE
 
 #endif // SORTERSSORTERCONTAINER_H


### PR DESCRIPTION
SortFilterProxyModel doesn't currently support Qt built with the -qtnamespace configure option