### PR TITLE
Remove warning when compiling using c++17

### DIFF
--- a/SortFilterProxyModel.pri
+++ b/SortFilterProxyModel.pri
@@ -1,4 +1,4 @@
-!contains( CONFIG, c\+\+1[14] ): warning("SortFilterProxyModel needs at least c++11, add CONFIG += c++11 to your .pro")
+!contains( CONFIG, c\+\+1[147] ): warning("SortFilterProxyModel needs at least c++11, add CONFIG += c++11 to your .pro")
 
 INCLUDEPATH += $$PWD
 


### PR DESCRIPTION
When using CONFIG+=c++17, the warning "SortFilterProxyModel needs at least c++11, add CONFIG += c++11 to your .pro" is shown even though c++17 is at least c++11