### PR TITLE
Add support for Qt versions < 5.9

### DIFF
--- a/filters/filtercontainer.cpp
+++ b/filters/filtercontainer.cpp
@@ -2,6 +2,10 @@
 #include "filter.h"
 #include <QtQml>
 
+#if (QT_VERSION < QT_VERSION_CHECK(5, 9, 0))
+#define qmlWarning(me) qmlInfo(me)
+#endif
+
 namespace qqsfpm {
 
 /*!

--- a/sorters/sortercontainer.cpp
+++ b/sorters/sortercontainer.cpp
@@ -2,6 +2,10 @@
 #include "sorter.h"
 #include <QtQml>
 
+#if (QT_VERSION < QT_VERSION_CHECK(5, 9, 0))
+#define qmlWarning(me) qmlInfo(me)
+#endif
+
 namespace qqsfpm {
 
 /*!


### PR DESCRIPTION
Qt versions prior to Qt 5.9 do not have the qmlWarning(). For those
versions redefine qmlWarning() to call qmlInfo() instead.